### PR TITLE
add_host_option

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "url": "git+https://github.com/tatsuo48/blog.git"
     },
     "scripts": {
-        "dev": "gatsby develop",
+        "dev": "gatsby develop --host 0.0.0.0",
         "build": "gatsby build"
     }
 }


### PR DESCRIPTION
コンテナとして起動させるとホストからつながるようにするために--host 0.0.0.0が必要